### PR TITLE
Added pause functionality for load cell callibration modals.

### DIFF
--- a/RocketControlUnitGUI/src/lib/components/PausablePromptModal.svelte
+++ b/RocketControlUnitGUI/src/lib/components/PausablePromptModal.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { getModalStore } from '@skeletonlabs/skeleton';
+
+    const modalStore = getModalStore();
+
+    export let heading: string = "";
+    export let inputMethod: "text" | "number" = "text";
+
+    const finish = (value: "submit" | "cancel" | "pause") => {
+        $modalStore[0].response!(value);
+    }
+
+    const cancel = () => {
+        modalStore.close();
+        finish("cancel");
+    }
+</script>
+
+<div class="">
+    <header>{heading}</header>
+    <input type={inputMethod} />
+    <div class="modal-actions">
+        <button on:click={() => finish("submit")}>Submit</button>
+        <button on:click={() => finish("pause")}>Pause</button>
+        <button on:click={cancel}>Cancel</button>
+    </div>
+</div>

--- a/RocketControlUnitGUI/src/lib/components/PausablePromptModal.svelte
+++ b/RocketControlUnitGUI/src/lib/components/PausablePromptModal.svelte
@@ -1,27 +1,39 @@
+<script lang="ts" context="module">
+    export type PausablePromptResponse = ["submit" | "cancel" | "pause" | undefined, string];
+</script>
+
 <script lang="ts">
 	import { getModalStore } from '@skeletonlabs/skeleton';
 
     const modalStore = getModalStore();
 
     export let heading: string = "";
-    export let inputMethod: "text" | "number" = "text";
+    let inputValue: string = "";
 
-    const finish = (value: "submit" | "cancel" | "pause") => {
-        $modalStore[0].response!(value);
+    const finish = (value: PausablePromptResponse) => {
+        $modalStore[0]?.response!(value);
+        modalStore.close();
+    }
+
+    const submit = () => {
+        finish(["submit", inputValue]);
+    }
+
+    const pause = () => {
+        finish(["pause", inputValue]);
     }
 
     const cancel = () => {
-        modalStore.close();
-        finish("cancel");
+        finish(["cancel", ""]);
     }
 </script>
 
 <div class="">
     <header>{heading}</header>
-    <input type={inputMethod} />
+    <input bind:value={inputValue} type="text" />
     <div class="modal-actions">
-        <button on:click={() => finish("submit")}>Submit</button>
-        <button on:click={() => finish("pause")}>Pause</button>
+        <button on:click={submit}>Submit</button>
+        <button on:click={pause}>Pause</button>
         <button on:click={cancel}>Cancel</button>
     </div>
 </div>

--- a/RocketControlUnitGUI/src/lib/components/PausablePromptModal.svelte
+++ b/RocketControlUnitGUI/src/lib/components/PausablePromptModal.svelte
@@ -28,12 +28,12 @@
     }
 </script>
 
-<div class="">
-    <header>{heading}</header>
-    <input bind:value={inputValue} type="text" />
-    <div class="modal-actions">
-        <button on:click={submit}>Submit</button>
-        <button on:click={pause}>Pause</button>
-        <button on:click={cancel}>Cancel</button>
-    </div>
+<div class="modal block overflow-y-auto bg-surface-100-800-token w-modal h-auto p-4 space-y-4 rounded-container-token shadow-xl">
+    <header class="modal-header text-2xl font-bold">{heading}</header>
+    <input class="modal-prompt-input input" bind:value={inputValue} type="text" />
+    <footer class="modal-footer flex justify-end space-x-2">
+        <button class="btn variant-ghost-surface" type="submit" on:click={cancel}>Cancel</button>
+        <button class="btn variant-filled" type="submit" on:click={pause}>Pause</button>
+        <button class="btn variant-filled" type="submit" on:click={submit}>Submit</button>
+    </footer>
 </div>

--- a/RocketControlUnitGUI/src/lib/hooks/useInteraction.ts
+++ b/RocketControlUnitGUI/src/lib/hooks/useInteraction.ts
@@ -112,6 +112,8 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 			}
 		};
 
+		let shouldReRun = false;
+
 		const modal: ModalSettings = {
 			type: 'component',
 			component: modalComponent,
@@ -121,7 +123,9 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 						// If this is the last weight, send the finish command
 						if (promptStates[loadcell].numberOfWeights === 1) {
 							pocketbaseHook.writeLoadCellCommand(loadcell, 'FINISH', parseFloat(res[1]));
+
 							delete promptStates[loadcell];
+							return;
 						} else {
 							// The modal was confirmed, send the calibrate command
 							pocketbaseHook.writeLoadCellCommand(loadcell, 'CALIBRATE', parseFloat(res[1]));
@@ -150,11 +154,6 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 
 	const resumeConfirmRemoveWeight = (loadcell: string) => {
 		if (!promptStates[loadcell] || !promptStates[loadcell].onResume) {
-			confirmRemoveWeight(loadcell);
-			return;
-		}
-
-		if (!promptStates[loadcell].onResume) {
 			confirmRemoveWeight(loadcell);
 			return;
 		}

--- a/RocketControlUnitGUI/src/lib/hooks/useInteraction.ts
+++ b/RocketControlUnitGUI/src/lib/hooks/useInteraction.ts
@@ -1,5 +1,6 @@
-import { getModalStore, type ModalSettings } from '@skeletonlabs/skeleton';
+import { getModalStore, type ModalComponent, type ModalSettings } from '@skeletonlabs/skeleton';
 import type { PocketbaseHook } from './usePocketbase';
+import PausablePromptModal from '$lib/components/PausablePromptModal.svelte';
 
 const stateToCommand: { [key: string]: string } = {
 	RS_ABORT: 'RSC_ANY_TO_ABORT',
@@ -91,28 +92,52 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 	};
 
 	const promptEnterWeight = (loadcell: string) => {
-		const modal: ModalSettings = {
-			type: 'prompt',
-			title: `Enter Weight (kg) (${numberOfWeights} remaining)`,
-			valueAttr: { type: 'text', required: true },
-			response: async (r: any) => {
-				if (r) {
-					// If this is the last weight, send the finish command
-					if (numberOfWeights === 1) {
-						pocketbaseHook.writeLoadCellCommand(loadcell, 'FINISH', parseFloat(r));
-					} else {
-						// The modal was confirmed, send the calibrate command
-						pocketbaseHook.writeLoadCellCommand(loadcell, 'CALIBRATE', parseFloat(r));
-					}
+		// const modal: ModalSettings = {
+		// 	type: 'prompt',
+		// 	title: `Enter Weight (kg) (${numberOfWeights} remaining)`,
+		// 	valueAttr: { type: 'text', required: true },
+		// 	response: async (r: any) => {
+		// 		if (r) {
+		// 			// If this is the last weight, send the finish command
+		// 			if (numberOfWeights === 1) {
+		// 				pocketbaseHook.writeLoadCellCommand(loadcell, 'FINISH', parseFloat(r));
+		// 			} else {
+		// 				// The modal was confirmed, send the calibrate command
+		// 				pocketbaseHook.writeLoadCellCommand(loadcell, 'CALIBRATE', parseFloat(r));
+		// 			}
 
-					// Decrease the number of weights and open the modal again if there are more weights to enter
-					numberOfWeights--;
-					if (numberOfWeights > 0) {
-						promptEnterWeight(loadcell);
-					}
-				} else {
-					// The modal was cancelled, send a cancel command
-					pocketbaseHook.writeLoadCellCommand(loadcell, 'CANCEL', 0);
+		// 			// Decrease the number of weights and open the modal again if there are more weights to enter
+		// 			numberOfWeights--;
+		// 			if (numberOfWeights > 0) {
+		// 				promptEnterWeight(loadcell);
+		// 			}
+		// 		} else {
+		// 			// The modal was cancelled, send a cancel command
+		// 			pocketbaseHook.writeLoadCellCommand(loadcell, 'CANCEL', 0);
+		// 		}
+		// 	}
+		// };
+
+		const modalComponent: ModalComponent = {
+			ref: PausablePromptModal,
+			props: {
+				heading: `Enter Weight (kg) (${numberOfWeights} remaining)`,
+				inputMethod: 'text'
+			}
+		};
+
+		const modal: ModalSettings = {
+			type: 'component',
+			component: modalComponent,
+			response: (res: 'submit' | 'cancel' | 'pause' | undefined) => {
+				switch (res) {
+					case 'submit':
+						break;
+					case 'pause':
+						break;
+					default:	// 'cancel' | undefined
+						pocketbaseHook.writeLoadCellCommand(loadcell, 'CANCEL', 0);
+						break;
 				}
 			}
 		};

--- a/RocketControlUnitGUI/src/lib/hooks/useInteraction.ts
+++ b/RocketControlUnitGUI/src/lib/hooks/useInteraction.ts
@@ -1,6 +1,6 @@
 import { getModalStore, type ModalComponent, type ModalSettings } from '@skeletonlabs/skeleton';
 import type { PocketbaseHook } from './usePocketbase';
-import PausablePromptModal from '$lib/components/PausablePromptModal.svelte';
+import PausablePromptModal, { type PausablePromptResponse } from '$lib/components/PausablePromptModal.svelte';
 
 const stateToCommand: { [key: string]: string } = {
 	RS_ABORT: 'RSC_ANY_TO_ABORT',
@@ -22,6 +22,13 @@ const commandToState = Object.fromEntries(
 
 Object.freeze(stateToCommand);
 Object.freeze(commandToState);
+
+interface LoadCellPromptStates {
+	[loadcell: string]: {
+		numberOfWeights: number,
+		onResume?: (loadcell: string) => void
+	}
+}
 
 export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 	const modalStore = getModalStore();
@@ -53,6 +60,8 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 		nextStatePending = '';
 	};
 
+	let promptStates: LoadCellPromptStates = {}
+
 	const confirmRemoveWeight = (loadcell: string) => {
 		const modal: ModalSettings = {
 			type: 'confirm',
@@ -70,8 +79,6 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 		modalStore.trigger(modal);
 	};
 
-	let numberOfWeights = 0;
-
 	const promptEnterNumberOfWeights = (loadcell: string) => {
 		const modal: ModalSettings = {
 			type: 'prompt',
@@ -80,10 +87,16 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 			response: async (r: any) => {
 				if (r) {
 					// The modal was confirmed, set the number of weights
-					numberOfWeights = parseInt(r);
-					if (numberOfWeights > 0) {
+					promptStates[loadcell] = {
+						numberOfWeights: parseInt(r)
+					};
+
+					if (promptStates[loadcell].numberOfWeights > 0) {
 						promptEnterWeight(loadcell);
 					}
+				}
+				else {
+					delete promptStates[loadcell];
 				}
 			}
 		};
@@ -92,51 +105,41 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 	};
 
 	const promptEnterWeight = (loadcell: string) => {
-		// const modal: ModalSettings = {
-		// 	type: 'prompt',
-		// 	title: `Enter Weight (kg) (${numberOfWeights} remaining)`,
-		// 	valueAttr: { type: 'text', required: true },
-		// 	response: async (r: any) => {
-		// 		if (r) {
-		// 			// If this is the last weight, send the finish command
-		// 			if (numberOfWeights === 1) {
-		// 				pocketbaseHook.writeLoadCellCommand(loadcell, 'FINISH', parseFloat(r));
-		// 			} else {
-		// 				// The modal was confirmed, send the calibrate command
-		// 				pocketbaseHook.writeLoadCellCommand(loadcell, 'CALIBRATE', parseFloat(r));
-		// 			}
-
-		// 			// Decrease the number of weights and open the modal again if there are more weights to enter
-		// 			numberOfWeights--;
-		// 			if (numberOfWeights > 0) {
-		// 				promptEnterWeight(loadcell);
-		// 			}
-		// 		} else {
-		// 			// The modal was cancelled, send a cancel command
-		// 			pocketbaseHook.writeLoadCellCommand(loadcell, 'CANCEL', 0);
-		// 		}
-		// 	}
-		// };
-
 		const modalComponent: ModalComponent = {
 			ref: PausablePromptModal,
 			props: {
-				heading: `Enter Weight (kg) (${numberOfWeights} remaining)`,
-				inputMethod: 'text'
+				heading: `Enter Weight (kg) (${promptStates[loadcell].numberOfWeights} remaining)`,
 			}
 		};
 
 		const modal: ModalSettings = {
 			type: 'component',
 			component: modalComponent,
-			response: (res: 'submit' | 'cancel' | 'pause' | undefined) => {
-				switch (res) {
+			response: (res: PausablePromptResponse) => {
+				switch (res[0]) {
 					case 'submit':
+						// If this is the last weight, send the finish command
+						if (promptStates[loadcell].numberOfWeights === 1) {
+							pocketbaseHook.writeLoadCellCommand(loadcell, 'FINISH', parseFloat(res[1]));
+							delete promptStates[loadcell];
+						} else {
+							// The modal was confirmed, send the calibrate command
+							pocketbaseHook.writeLoadCellCommand(loadcell, 'CALIBRATE', parseFloat(res[1]));
+						}
+
+						// Decrease the number of weights and open the modal again if there are more weights to enter
+						promptStates[loadcell].numberOfWeights--;
+						if (promptStates[loadcell].numberOfWeights > 0) {
+							promptEnterWeight(loadcell);
+						}
+
 						break;
 					case 'pause':
+						promptStates[loadcell].onResume = promptEnterWeight;
 						break;
 					default:	// 'cancel' | undefined
 						pocketbaseHook.writeLoadCellCommand(loadcell, 'CANCEL', 0);
+						delete promptStates[loadcell];
 						break;
 				}
 			}
@@ -145,9 +148,23 @@ export const useInteraction = (pocketbaseHook: PocketbaseHook) => {
 		modalStore.trigger(modal);
 	};
 
+	const resumeConfirmRemoveWeight = (loadcell: string) => {
+		if (!promptStates[loadcell] || !promptStates[loadcell].onResume) {
+			confirmRemoveWeight(loadcell);
+			return;
+		}
+
+		if (!promptStates[loadcell].onResume) {
+			confirmRemoveWeight(loadcell);
+			return;
+		}
+
+		promptStates[loadcell].onResume!(loadcell);
+	}
+
 	return {
 		confirmStateChange,
 		instantStateChange,
-		confirmRemoveWeight
+		resumeConfirmRemoveWeight,
 	};
 };

--- a/RocketControlUnitGUI/src/lib/hooks/usePocketbase.ts
+++ b/RocketControlUnitGUI/src/lib/hooks/usePocketbase.ts
@@ -1,11 +1,12 @@
 import PocketBase from 'pocketbase';
 import type { Timestamps } from '../timestamps';
 import type { Stores } from '../stores';
+import { currentState } from '../stores';
 
 export type PocketbaseHook = ReturnType<typeof usePocketbase>;
 
 export const usePocketbase = (timestamps: Timestamps, stores: Stores) => {
-	const pocketbase = new PocketBase('http://localhost:8090');
+	const pocketbase = new PocketBase('http://192.168.0.69:8090');
 
 	const authenticate = async () => {
 		const email = import.meta.env.VITE_EMAIL;
@@ -174,6 +175,7 @@ export const usePocketbase = (timestamps: Timestamps, stores: Stores) => {
 		// Subscribe to changes in the 'sys_state' collection
 		pocketbase.collection('sys_state').subscribe('*', (e) => {
 			stores.system_state.set(e.record.sys_state);
+			currentState.set(e.record.rocket_state);
 			timestamps.sys_state = Date.now();
 		});
 

--- a/RocketControlUnitGUI/src/routes/+page.svelte
+++ b/RocketControlUnitGUI/src/routes/+page.svelte
@@ -25,7 +25,7 @@
 	const {
 		confirmStateChange,
 		instantStateChange,
-		confirmRemoveWeight
+		resumeConfirmRemoveWeight
 	} = useInteractionHook;
 
 	// Destructure stores for later use
@@ -463,7 +463,7 @@
 			class="btn btn-sm variant-filled-error" 
 			on:click={() => {
 				writeLoadCellCommand("NOS1", "CANCEL", 0);
-				confirmRemoveWeight("NOS1");}}
+				resumeConfirmRemoveWeight("NOS1");}}
 		>
 			CAL
 		</button>
@@ -485,7 +485,7 @@
 			class="btn btn-sm variant-filled-error" 
 			on:click={() => {
 				writeLoadCellCommand("NOS2", "CANCEL", 0);	
-				confirmRemoveWeight("NOS2");}}
+				resumeConfirmRemoveWeight("NOS2");}}
 		>
 			CAL
 		</button>
@@ -507,7 +507,7 @@
 			class="btn btn-sm variant-filled-error" 
 			on:click={() => { 
 				writeLoadCellCommand("LAUNCHRAIL", "CANCEL", 0);
-				confirmRemoveWeight("LAUNCHRAIL");}}
+				resumeConfirmRemoveWeight("LAUNCHRAIL");}}
 		>
 			CAL
 		</button>


### PR DESCRIPTION
Modal state when configuring individual load cells is saved if the "pause" button is pressed. Clicking "cancel" will erase its state, effectively resetting the modal sequence.

I created a new component called `PausablePromptModal` which still needs styled. @Jgerbrandt, are you able to provide the tailwind for that?